### PR TITLE
Modify formatting for if and for loops to match java style guide

### DIFF
--- a/snippets/for.sublime-snippet
+++ b/snippets/for.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-for(Integer i = ${1:0}; i ${2:<} ${3:sObjectList.size()}; i${4:++}) {
+for (Integer i = ${1:0}; i ${2:<} ${3:sObjectList.size()}; i${4:++}) {
 	${0}
 }
 ]]></content>

--- a/snippets/foreeach.sublime-snippet
+++ b/snippets/foreeach.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-for(${1:sObject} ${2:sObj}: ${3:sObjList}) {
+for (${1:sObject} ${2:sObj}: ${3:sObjList}) {
 	${0}
 }
 ]]></content>

--- a/snippets/if.sublime-snippet
+++ b/snippets/if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-if(${1:condition}) {
+if (${1:condition}) {
 	${0}
 }
 ]]></content>

--- a/snippets/ifIsBlank.sublime-snippet
+++ b/snippets/ifIsBlank.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-if(String.isBlank(${1:str})) {
+if (String.isBlank(${1:str})) {
 	${0}
 }
 ]]></content>

--- a/snippets/ifIsNotBlank.sublime-snippet
+++ b/snippets/ifIsNotBlank.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-if(String.isNotBlank(${1:str})) {
+if (String.isNotBlank(${1:str})) {
 	${0}
 }
 ]]></content>

--- a/snippets/ifelse.sublime-snippet
+++ b/snippets/ifelse.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-if(${1:condition}) {
+if (${1:condition}) {
 	${2:// if true}
 } else {
 	${0:// if false}


### PR DESCRIPTION
Apex should adhere to Java style guide: https://google.github.io/styleguide/javaguide.html#s4.6.2-horizontal-whitespace.
There should be 1 space before open parenthesis in `if (` and `for (`